### PR TITLE
2 pruebas más correcciones en el algoritmo

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,14 @@ function salario(horas, valorHora) {
 
     if (!soloInt.test(horas) || !soloInt.test(valorHora)) return 'valores invalidos'
 
-    if (horas <= 60) {
-        informe['bruto'] = horas * valorHora
+    if (horas <= 60) {        
         if (horas > 48) {
-            informe['extra'] = informe['bruto'] + (valorHora * 0.2) * (horas - 48)
+            informe['bruto'] = 48 * valorHora
+            informe['extra'] =(valorHora * 1.2) * (horas - 48)
+        }else{
+            informe['bruto'] = horas * valorHora
         }
-        informe['neto'] = informe['bruto'] + informe['neto']
+        informe['neto'] = informe['bruto'] + informe['extra']
         return informe
     } else{
         return 'valores invalidos'

--- a/index.test.js
+++ b/index.test.js
@@ -23,3 +23,7 @@ test('Solo Valores Numericos en salrio ',()=>{
 test('Calculo del valor a pagar por las horas Extra',()=>{
     expect(salario(49,3000).extra).toBe(3600)
 })
+
+test('Calculo del valor del salario neto',()=>{
+    expect(salario(49,3000).neto).toBe(147600)
+})

--- a/index.test.js
+++ b/index.test.js
@@ -11,3 +11,15 @@ test('si son 48 horas o menos de trabajo, no se pagan horas extras', () =>{
 test('no valores negativos en horas', () =>{
     expect(salario(-20,30000)).toMatch('valores invalidos')
 })
+
+test('Solo Valores Numericos en horas',()=>{
+    expect(salario('ba',3000)).toMatch('valores invalidos')
+})
+
+test('Solo Valores Numericos en salrio ',()=>{
+    expect(salario(40,'ba')).toMatch('valores invalidos')
+})
+
+test('Calculo del valor a pagar por las horas Extra',()=>{
+    expect(salario(49,3000).extra).toBe(3600)
+})


### PR DESCRIPTION
corregi el algoritmo del calculo del salario ya que estaba mal desarrollado y funcionaba deficientemente a la hora de calcular el pago por las horas extra y el salario neto
se añaden 2 pruebas que en realidad son 3:
las primeras dos solo verifican que no se pueda poner texto ni en horas ni en salario individualmente
la ultima que si se calcule bien el valor al pagar por las horas extra